### PR TITLE
removed profileData state from profile page, now everything depends o…

### DIFF
--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -8,20 +8,10 @@ import MealPlanHistory from "./MealPlanHistory";
 import Container from "@/components/Container";
 
 const Profile = () => {
-  const { user, token } = AuthData();
   const [loading, setLoading] = useState(false);
   
   const [weightHistory, setWeightHistory] = useState();
-  
-  const [profileData, setProfileData] = useState({
-    name: user.name || "",
-    email: user.email || "",
-    gender: user.gender || "",
-    height: user.height || "",
-    weight: user.weight || 0,
-    age: user.age || "",
-    currentCalorieIntake: user.currentCalorieIntake || 0
-  });
+ 
 
   
 
@@ -41,7 +31,7 @@ const Profile = () => {
         </TabsList>
         <Container className={`sm:max-w-[30rem] md:max-w-[40rem] lg:max-w-[60rem] my-12`} >
           <TabsContent value="profile">
-            <ProfileData profileData={profileData} setProfileData={setProfileData}/>
+            <ProfileData/>
           </TabsContent>
           <TabsContent value="charts">
             <UserCharts setWeightHistory={setWeightHistory} weightHistory={weightHistory} />

--- a/src/pages/Profile/ProfileData.jsx
+++ b/src/pages/Profile/ProfileData.jsx
@@ -48,7 +48,7 @@ const Field = ({ label, icon, error, inputProps }) => {
   );
 };
 
-const ProfileData = ({ profileData, setProfileData }) => {
+const ProfileData = () => {
   const { triggerToast } = useNotification();
   const { user, setUser, token } = AuthData();
   const [loading, setLoading] = useState(true);
@@ -61,12 +61,12 @@ const ProfileData = ({ profileData, setProfileData }) => {
     formState: { errors },
   } = useForm({
     resolver: zodResolver(profileFormSchema),
-    defaultValues: profileData,
+    defaultValues: user,
   });
 
   useEffect(() => {
-    reset(profileData);
-  }, [profileData, reset]);
+    reset(user);
+  }, [user, reset]);
 
   const onSubmit = async (data) => {
     const updatedProfile = {};


### PR DESCRIPTION
# Pull Request: Refactor ProfileData to Use User Context

## Description

This PR refactors the `ProfileData` component to use the `user` object directly from the `AuthData()` context instead of relying on `profileData` passed via props.

## Changes Made

- Removed `profileData` and `setProfileData` props from the `ProfileData` component.
- Simplified state management by eliminating potential sync issues between prop-based and context-based user data.
- Ensured consistent behavior when navigating between components without requiring a full page reload.

## Why This Is Important

Previously, the updated profile data was only reflected immediately after submission. Navigating away and back to the profile would show outdated data unless the page was reloaded.

By using context:
- We maintain a single, reliable source of user data.
- Avoid stale state issues.
- Improve user experience and maintain data consistency across the app.

## Notes

Make sure any parent components or pages using `<ProfileData />` no longer pass `profileData` as props.
